### PR TITLE
Cancel process on download error

### DIFF
--- a/packages/app/pages/MainPage.tsx
+++ b/packages/app/pages/MainPage.tsx
@@ -347,9 +347,18 @@ export const MainPage: React.FC<{}> = (props) => {
                 "Downloading compressed proving files... (this may take a few minutes)"
               );
               setStatus("downloading-proof-files");
-              await downloadProofFiles(filename, () => {
-                setDownloadProgress((p) => p + 1);
-              });
+              try {
+                await downloadProofFiles(filename, () => {
+                  setDownloadProgress((p) => p + 1);
+                });
+              }
+              catch (e) {
+                console.log(e);
+                setDisplayMessage("Error downloading proof files");
+                setStatus("error-failed-to-download");
+                return;
+              }
+
               console.timeEnd("zk-dl");
               recordTimeForActivity("finishedDownloading");
 


### PR DESCRIPTION
If the download before proof generation fails, cancel the process and display "Error downloading proof files".
Fixes #1
