### PR TITLE
[chore] Update aliases to include node:buffer and node:stream

### DIFF
--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -14,6 +14,8 @@ export default {
   plugins: [commonjs(), react(), tsconfig()],
   resolve: {
     alias: {
+      "node:buffer": "buffer",
+      "node:stream": "stream-browserify",
       buffer: "buffer",
       process: "rollup-plugin-node-polyfills/polyfills/process-es6",
       util: "rollup-plugin-node-polyfills/polyfills/util",


### PR DESCRIPTION
- Looks like one of the dependencies `libmime` needs a strict polyfill against `node:buffer` and `node:stream`.
- This was broken locally on my mac, applying the above patch fixes the issue.

In the below error, `libbase64` is trying to subclass `"node:stream".Transform`, which has not been correctly polyfilled.

original error:
<img width="664" alt="image" src="https://github.com/zkemail/proof-of-twitter/assets/2030176/905231ad-3b05-4700-a1d8-dee2845d1d88">

vite documentation: https://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility